### PR TITLE
Disable dnstt

### DIFF
--- a/IEnvoyProxy/IEnvoyProxy.go
+++ b/IEnvoyProxy/IEnvoyProxy.go
@@ -7,20 +7,9 @@ import (
 	"net"
 	"strconv"
 	"time"
-	dnsttclient "www.bamsoftware.com/git/dnstt.git/dnstt-client"
 	hysteria "github.com/tobyxdd/hysteria/cmd"
 	v2ray "github.com/v2fly/v2ray-core/envoy"
 )
-
-var dnsttPort = 57000
-
-// DnsttPort - Port where Dnstt will provide its service.
-// Only use this property after calling StartDnstt! It might have changed after that!
-//
-//goland:noinspection GoUnusedExportedFunction
-func DnsttPort() int {
-	return dnsttPort
-}
 
 var hysteriaPort = 47500
 
@@ -49,67 +38,10 @@ func V2rayWsPort() int {
 	return v2rayWsPort
 }
 
-var dnsttRunning = false
 var hysteriaRunning = false
 var v2rayWsRunning = false
 var v2raySrtpRunning = false
 var v2rayWechatRunning = false
-
-
-// StartDnstt - Start the Dnstt client.
-//
-// @param ttDomain	subdomain name for DNSTT
-//
-// @param dohURL OPTIONAL. URL of a DoH resolver. Use either this or `dotAddr`.
-//
-// @param dotAddr OPTIONAL. Address of a DoT resolver. Use either this or `dohURL`.
-//
-// @param pubkey The DNSTT's server public key (as hex digits).
-//
-// @return Port number where Dnstt will listen on, if no error happens during start up.
-//
-//goland:noinspection GoUnusedExportedFunction
-func StartDnstt(ttDomain, dohURL, dotAddr, pubkey string) int {
-	log.Println("Starting DNSTT")
-	if dnsttRunning {
-		log.Printf("DNSTT already running on port %d", dnsttPort)
-		return dnsttPort
-	}
-
-	dnsttRunning = true
-
-	dnsttPort = findPort(dnsttPort)
-
-	// From the dnstt docs:
-	//
-	// In -doh and -dot modes, the program's TLS fingerprint is camouflaged with
-	// uTLS by default. The specific TLS fingerprint is selected randomly from a
-	// weighted distribution. You can set your own distribution (or specific single
-	// fingerprint) using the -utls option. The special value "none" disables uTLS.
-	//     -utls '3*Firefox,2*Chrome,1*iOS'
-	//     -utls Firefox
-	//     -utls none
-	var utlsDistribution = "3*Firefox,1*iOS"
-	var listenAddr = fmt.Sprintf("localhost:%d", dnsttPort)
-
-	go dnsttclient.Start(&ttDomain, &listenAddr, &dohURL, &dotAddr, &pubkey, &utlsDistribution)
-	log.Println("DNSTT started on port %d", dnsttPort)
-
-	return dnsttPort
-}
-
-// StopDnstt - Stop the Dnstt client.
-//
-//goland:noinspection GoUnusedExportedFunction
-func StopDnstt() {
-	if !dnsttRunning {
-		return
-	}
-
-	go dnsttclient.Stop()
-
-	dnsttRunning = false
-}
 
 type HysteriaListen struct {
 	Listen string `json:"listen"`

--- a/IEnvoyProxy/go.mod
+++ b/IEnvoyProxy/go.mod
@@ -8,7 +8,6 @@ replace (
 	github.com/pion/dtls/v2 => github.com/pion/dtls/v2 v2.0.12
 	github.com/tobyxdd/hysteria v1.0.5 => ../hysteria
 	github.com/v2fly/v2ray-core v4.15.0+incompatible => ../v2ray-core
-	www.bamsoftware.com/git/dnstt.git => ../dnstt
 )
 
 require (
@@ -23,5 +22,4 @@ require (
 	github.com/v2fly/v2ray-core/v5 v5.0.7 // indirect
 	golang.org/x/crypto v0.0.0-20220516162934-403b01795ae8 // indirect
 	golang.org/x/mobile v0.0.0-20221110043201-43a038452099 // indirect
-	www.bamsoftware.com/git/dnstt.git v0.0.0-00010101000000-000000000000
 )

--- a/build.sh
+++ b/build.sh
@@ -26,9 +26,6 @@ go install golang.org/x/mobile/cmd/gomobile@latest
 printf '\n\n--- Fetching submodule dependencies...\n'
 if test -e ".git"; then
     # There's a .git directory - we must be in the development pod.
-    git submodule update --init --recursive
-    cd dnstt || exit 1
-    git reset --hard
     cd ../hysteria || exit 1
     git reset --hard
     cd ../v2ray-core || exit 1
@@ -37,10 +34,6 @@ if test -e ".git"; then
     cd ..
 else
     # No .git directory - That's a normal install.
-    git clone https://www.bamsoftware.com/git/dnstt.git
-    cd dnstt || exit 1
-    git checkout --force --quiet 04f04590
-    cd ..
     git clone https://github.com/HyNetwork/hysteria.git
     cd hysteria || exit 1
     git checkout --force --quiet da16c88
@@ -54,7 +47,6 @@ fi
 # Apply patches.
 printf '\n\n--- Apply patches to submodules...\n'
 echo `pwd`
-patch --directory=dnstt --strip=1 < dnstt.patch
 patch --directory=hysteria --strip=1 < hysteria.patch
 patch --directory=v2ray-core --strip=1 < v2ray-core.patch
 

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -euo pipefail
+
 TARGET=ios,iossimulator,macos
 OUTPUT=IEnvoyProxy.xcframework
 

--- a/build.sh
+++ b/build.sh
@@ -26,7 +26,7 @@ go install golang.org/x/mobile/cmd/gomobile@latest
 printf '\n\n--- Fetching submodule dependencies...\n'
 if test -e ".git"; then
     # There's a .git directory - we must be in the development pod.
-    cd ../hysteria || exit 1
+    cd hysteria || exit 1
     git reset --hard
     cd ../v2ray-core || exit 1
     git reset --hard


### PR DESCRIPTION
This disables DNSTT and removes it from the build. I just realized I forgot the submodule, I'll remove that too

We're not currently using DNSTT, so we can take it out to simplify and reduce binary size and code complexity 