### PR TITLE
Fixed Podspec

### DIFF
--- a/IEnvoyProxy.podspec
+++ b/IEnvoyProxy.podspec
@@ -53,20 +53,6 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '12.0'
   s.osx.deployment_target = '11'
 
-  s.preserve_paths = 'build.sh', '*.patch', 'IEnvoyProxy/*'
-
-  # This will only be executed once.
-  s.prepare_command = './build.sh'
-
-  # That's why this is also here, albeit it will be too late here.
-  # You will need to re-run `pod update` to make the last line work.
-  s.script_phase = {
-    :name => 'Go build of IEnvoyProxy.xcframework',
-    :execution_position => :before_compile,
-    :script => 'sh "$PODS_TARGET_SRCROOT/build.sh"',
-    :output_files => ['$(DERIVED_FILE_DIR)/IEnvoyProxy.xcframework'],
-  }
-
   # This will only work, if `prepare_command` was successful, or if you
   # called `pod update` a second time after a build which will have triggered
   # the `script_phase`, or if you ran `build.sh` manually.


### PR DESCRIPTION
Removed build commands which break the install, since we now use a precompiled lib from Github.

- Sorry, I didn't recognize that problem at first, due to the way CocoaPods works.