### PR TITLE
Added script to create Apple bundle.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,3 +154,4 @@ iOSInjectionProject/
 IEnvoyProxy-sources.jar
 IEnvoyProxy.aar
 IEnvoyProxy.xcframework
+IEnvoyProxy.xcframework.zip

--- a/bundle-apple.sh
+++ b/bundle-apple.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+zip -r -9 -o IEnvoyProxy.xcframework.zip IEnvoyProxy.xcframework LICENSE


### PR DESCRIPTION
Using this script for packing the zip file will get rid of the annoying warning "Unable to read the license file `LICENSE` for the spec" CocoaPods warning.

Please run this script and replace `IEnvoyProxy.xcframework` [here](https://github.com/stevenmcdonald/IEnvoyProxy/releases/tag/e3.0.0) with the result of that script. 

Thank you!